### PR TITLE
Changing deploy function to only build and zip

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,20 +7,19 @@ echo
 printf "============================\n"
 printf "Blog built \n"
 printf "============================\n"
+
 echo
 printf "============================\n"
 printf "Deploying to EC2 instance\n"
 printf "============================\n"
 echo
+
 zip -r public.zip public/ 
-rsync -azP public.zip ubuntu@matabit.org:/home/ubuntu/hugo/
+cp -R public.zip ~/CIT480/matabit-infrastructure/Ansible/roles/hugo/templates
 echo
-ssh ubuntu@matabit.org << EOF
-  sudo unzip -o hugo/public.zip -d /var/www/matabit-blog
-  sudo chown -hR www-data:www-data /var/www/matabit-blog
-EOF
+
 echo
 printf "============================\n"
-printf "Blog has been deployed\n" 
+printf "Blog has been built and zipped\n" 
 printf "============================\n"
 echo


### PR DESCRIPTION
No longer manually using ssh to deploy blog. Anisble handles the deployment. 